### PR TITLE
feat: converted to single channel

### DIFF
--- a/ledcube/cube.go
+++ b/ledcube/cube.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	WIDTH  = 8
-	HEIGHT = 8
-	DEPTH  = 8
+	WIDTH  = 4
+	HEIGHT = 4
+	DEPTH  = 4
 )
 
 func InitCube() *mock.Cube {

--- a/ledcube/cube_linux_arm64.go
+++ b/ledcube/cube_linux_arm64.go
@@ -26,6 +26,7 @@ func (c *LedCube) Render() error {
 func (c *LedCube) SetLeds(f frames.Frame) error {
 	leds_fixed := formatFrame(f.ToXYZ())
 	leds := make([]uint32, len(leds_fixed))
+	copy(leds, leds_fixed[:])
 	return (*ws2811.WS2811)(c).SetLedsSync(CHANNEL, leds)
 }
 
@@ -53,6 +54,7 @@ func InitCube() *LedCube {
 }
 
 func formatFrame(frame [][][]uint32) [LED_COUNT]uint32 {
+	// TODO: implement this
 	var leds [LED_COUNT]uint32
 	return leds
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Convert LED cube to single channel and reduce dimensions to 4x4x4, simplifying initialization and LED setting logic.
> 
>   - **Behavior**:
>     - Convert LED cube to single channel in `cube_linux_arm64.go`.
>     - Reduce cube dimensions from 8x8x8 to 4x4x4 in `cube.go` and `cube_linux_arm64.go`.
>     - Simplify `SetLeds` to handle single channel.
>   - **Initialization**:
>     - Update `InitCube` to configure single channel with `CHANNEL`, `GPIO_PIN`, `LED_COUNT`, and `BRIGHTNESS`.
>   - **Misc**:
>     - Remove dual channel logic and related constants.
>     - `formatFrame` function remains unimplemented.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fhardware-led-cube&utm_source=github&utm_medium=referral)<sup> for 19fa40d3468c6c27f09d6e420167941b20b33478. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->